### PR TITLE
daplink probe gets stuck on FT4232H MiniModule on illumos

### DIFF
--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -192,7 +192,14 @@ pub fn open_device_from_selector(
             };
 
             let timeout = Duration::from_millis(100);
-            let sn_str = handle.read_languages(timeout)?.get(0).and_then(|lang| {
+            let langs = match handle.read_languages(timeout) {
+                Ok(langs) => langs,
+                Err(e) => {
+                    log::debug!("could not read languages: {:?}", e);
+                    continue;
+                }
+            };
+            let sn_str = langs.get(0).and_then(|lang| {
                 handle
                     .read_serial_number_string(*lang, &d_desc, timeout)
                     .ok()


### PR DESCRIPTION
On illumos systems the USB stack does not allow control transfers to
devices that are bound to drivers and choose not to expose ugen.  The
daplink probe routine attempts to make transfers to the FTDI FT4232H
MiniModule UART board and fails.  As this is not even a candidate
device, rather than throw up our hands we should keep scanning with the
next available device.