### PR TITLE
bump HID API and serialport deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,27 +3,6 @@
 version = 4
 
 [[package]]
-name = "CoreFoundation-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
-dependencies = [
- "libc",
- "mach",
-]
-
-[[package]]
-name = "IOKit-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
-dependencies = [
- "CoreFoundation-sys",
- "libc",
- "mach",
-]
-
-[[package]]
 name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +295,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-udev"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
 
 [[package]]
 name = "bincode"
@@ -1724,12 +1709,16 @@ checksum = "befe65164a090041cdf6e0d21a0ec3198d856fbfe2b76e324a073e790bb49f8c"
 
 [[package]]
 name = "hidapi"
-version = "1.4.1"
-source = "git+https://github.com/oxidecomputer/hidapi-rs?branch=oxide-stable#69f84deac74461bfc08adefd1feb8abe4fcdda26"
+version = "2.6.6"
+source = "git+https://github.com/oxidecomputer/hidapi-rs?branch=oxide-v2.6.6#74fcda94106181a4dca32370727b794011489afd"
 dependencies = [
+ "basic-udev",
  "cc",
+ "cfg-if",
  "libc",
+ "nix 0.30.1",
  "pkg-config",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2047,6 +2036,16 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.4.3",
+]
+
+[[package]]
+name = "io-kit-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
@@ -2226,26 +2225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libz-rs-sys"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,15 +2334,6 @@ checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
  "crc",
  "sha2",
-]
-
-[[package]]
-name = "mach"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2515,9 +2485,9 @@ checksum = "24e0cc5e2c585acbd15c5ce911dff71e1f4d5313f43345873311c4f5efd741cc"
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -2638,7 +2608,7 @@ dependencies = [
  "core-foundation-sys",
  "devinfo",
  "futures-core",
- "io-kit-sys",
+ "io-kit-sys 0.5.0",
  "libc",
  "linux-raw-sys",
  "log",
@@ -3867,17 +3837,18 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.1-alpha.0"
-source = "git+https://github.com/jgallagher/serialport-rs?branch=illumos-support#36c9f0e0292eac32215ab77c5847bf7afb13f000"
+version = "4.7.1-alpha.0"
+source = "git+https://github.com/oxidecomputer/serialport-rs?branch=illumos-support-4.7.1#8d0fd3a8a226b9160dc6c11f15235e5455bcbdb5"
 dependencies = [
- "CoreFoundation-sys",
- "IOKit-sys",
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "cfg-if",
- "libudev",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys 0.4.1",
  "mach2 0.4.3",
- "nix 0.24.3",
- "regex",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
  "winapi",
 ]
 
@@ -4776,6 +4747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -21,7 +21,6 @@ exclude = ["tests/"]
 
 [features]
 default = ["builtin-targets", "cmsisdap_v1"]
-serialport = ["dep:serialport"]
 
 # Enable all built in targets.
 builtin-targets = ["dep:bincode", "dep:serde_yaml", "dep:probe-rs-target"]
@@ -40,7 +39,7 @@ probe-rs-target.workspace = true
 bincode = { version = "2", features = ["serde"], optional = true }
 bitfield = "0.19.0"
 bitvec = "1"
-hidapi = { git = "https://github.com/oxidecomputer/hidapi-rs", branch = "oxide-stable", optional = true }
+hidapi = { git = "https://github.com/oxidecomputer/hidapi-rs", branch = "oxide-v2.6.6", optional = true, default-features = false, features = ["linux-native-basic-udev", "illumos-static-libusb"] }
 ihex = "3.0"
 itertools = "0.14"
 jep106 = "0.3"
@@ -53,7 +52,9 @@ object = { version = "0.38", default-features = false, features = [
 nusb = { git = "https://github.com/oxidecomputer/nusb.git", branch = "add_illumos" }
 futures-lite = { version = "2", default-features = false }
 scroll = "0.13"
-serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support", optional = true }
+serialport = { git = "https://github.com/oxidecomputer/serialport-rs", branch = "illumos-support-4.7.1", default-features = false, features = [
+    "usbportinfo-interface",
+]}
 tracing = "0.1"
 uf2-decode = "0.2"
 espflash = { version = "4", default-features = false }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -2,7 +2,6 @@
 pub(crate) mod common;
 pub(crate) mod usb_util;
 
-#[cfg(feature = "serialport")]
 pub mod blackmagic;
 pub mod ch347usbjtag;
 pub mod cmsisdap;
@@ -12,7 +11,6 @@ pub mod ftdi;
 pub mod glasgow;
 pub mod jlink;
 pub mod list;
-#[cfg(feature = "serialport")]
 pub mod sifliuart;
 pub mod stlink;
 pub mod wlink;

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -6,10 +6,8 @@ use crate::probe::{
 
 use super::{ch347usbjtag, cmsisdap, espusbjtag, ftdi, glasgow, jlink, stlink, wlink};
 
-#[cfg(feature = "serialport")]
 use super::blackmagic;
 
-#[cfg(feature = "serialport")]
 use super::sifliuart;
 
 /// Struct to list all attached debug probes
@@ -123,7 +121,6 @@ impl Default for AllProbesLister {
 
 impl AllProbesLister {
     const DRIVERS: &'static [&'static dyn ProbeFactory] = &[
-        #[cfg(feature = "serialport")]
         &blackmagic::BlackMagicProbeFactory,
         &cmsisdap::CmsisDapFactory,
         &ftdi::FtdiProbeFactory,
@@ -131,7 +128,6 @@ impl AllProbesLister {
         &jlink::JLinkFactory,
         &espusbjtag::EspUsbJtagFactory,
         &wlink::WchLinkFactory,
-        #[cfg(feature = "serialport")]
         &sifliuart::SifliUartFactory,
         &glasgow::GlasgowFactory,
         &ch347usbjtag::Ch347UsbJtagFactory,


### PR DESCRIPTION
We get some compilation errors for some humility lib use cases if we try and use the older hidapi/serialport.

Also just drop the attempt to compile out serialport. It worked well enough but it's not actually solving anything now.